### PR TITLE
Enable PAC responder

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     - adcli
     - sssd-krb5
     - sssd-ldap
+    - sssd-common-pac
     - krb5-workstation
 
 # krb5.conf

--- a/templates/sssd.conf.j2
+++ b/templates/sssd.conf.j2
@@ -1,6 +1,6 @@
 [sssd]
 config_file_version = 2
-services = nss, pam
+services = nss, pam, pac
 domains = {{ adauth_realm }}
 
 [nss]


### PR DESCRIPTION
This allows sssd to decode the MS PAC blob that AD servers attach to krb tickets. Enables faster logins.
