### PR TITLE
Use kernel keyring for kerberos ticket cache

### DIFF
--- a/templates/krb5.conf.j2
+++ b/templates/krb5.conf.j2
@@ -8,6 +8,7 @@
  allow_weak_crypto = yes
 {% endif %}
  default_keytab_name = FILE:/etc/krb5.keytab
+ default_ccache_name = KEYRING:persistent:%{uid}
  default_realm = {{ adauth_realm }}
  ticket_lifetime = 24h
  # AD doesn't allow more

--- a/templates/sssd.conf.j2
+++ b/templates/sssd.conf.j2
@@ -30,6 +30,7 @@ krb5_renew_interval = 6000
 krb5_lifetime = 604800
 krb5_canonicalize = false
 krb5_use_enterprise_principal = true
+krb5_ccname_template = KEYRING:persistent:%U
 ldap_access_order = expire
 ldap_account_expire_policy = ad
 ldap_pwd_policy = mit_kerberos


### PR DESCRIPTION
This should be more secure, and also allows kerberos to work when using polyinstantiated /tmp for each job (otherwise krb ticket cache is masked by the bind mounted /tmp).
