### PR TITLE
include warns of depreciation for ansible 2.4, changed to include_tas…

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
-  min_ansible_version: 1.2
+  min_ansible_version: 2.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,6 @@
 
 # actual configuration for NSS and PAM should be in another module to allow flexibility with other authentication methods
 
-- include: redhat.yml
+- include_tasks: redhat.yml
   when: adauth_enabled and ansible_os_family == "RedHat"
 


### PR DESCRIPTION
…ks instead

I'm preempting ansible 2.4 getting out on centos7 and everybody getting nervous.
include should be replaced by import_tasks or include_tasks depending on flow of logic.